### PR TITLE
Refactor: Move SplashActivity and configure Crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,11 +49,15 @@ android {
             resValue("string", "ads_application_id", apikeyProperties["ADMOB_ID_PROD"])
             resValue("string", "admob_banner_id", apikeyProperties["ADMOB_ID_BANNER_PROD"])
             resValue("string", "admob_reward_id", apikeyProperties["ADMOB_ID_REWARD_PROD"])
+            buildConfigField "boolean", "ENABLE_CRASHLYTICS", "true"
+            buildConfigField "boolean", "ENABLE_ADS", "true"
         }
 
         debug {
             debuggable true
             minifyEnabled false
+            buildConfigField "boolean", "ENABLE_CRASHLYTICS", "false"
+            buildConfigField "boolean", "ENABLE_ADS", "true"
             resValue("string", "ads_application_id", apikeyProperties["ADMOB_ID_DEV"])
             resValue("string", "admob_banner_id", apikeyProperties["ADMOB_ID_BANNER_DEV"])
             resValue("string", "admob_reward_id", apikeyProperties["ADMOB_ID_REWARD_DEV"])

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:maxSdkVersion="28" />
 
     <application
+        android:name=".App"
         android:allowBackup="true"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
@@ -18,7 +19,7 @@
         android:theme="@style/AppTheme">
 
         <activity
-            android:name="com.raylabs.doggie.SplashActivity"
+            android:name="com.raylabs.doggie.ui.splash.SplashActivity"
             android:exported="true"
             android:noHistory="true">
             <intent-filter>

--- a/app/src/main/java/com/raylabs/doggie/App.kt
+++ b/app/src/main/java/com/raylabs/doggie/App.kt
@@ -1,0 +1,14 @@
+package com.raylabs.doggie
+
+import android.app.Application
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+
+class App : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        FirebaseCrashlytics.getInstance().isCrashlyticsCollectionEnabled =
+            BuildConfig.ENABLE_CRASHLYTICS
+    }
+}

--- a/app/src/main/java/com/raylabs/doggie/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/raylabs/doggie/ui/splash/SplashActivity.kt
@@ -1,4 +1,4 @@
-package com.raylabs.doggie
+package com.raylabs.doggie.ui.splash
 
 import android.annotation.SuppressLint
 import android.content.Intent

--- a/app/src/main/java/com/raylabs/doggie/utils/AdsHelper.kt
+++ b/app/src/main/java/com/raylabs/doggie/utils/AdsHelper.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.os.Build
 import android.util.Log
+import android.view.View
 import android.widget.FrameLayout
 import com.google.android.gms.ads.AdError
 import com.google.android.gms.ads.AdListener
@@ -27,6 +28,7 @@ object AdsHelper {
     private var loadingRewarded = false
 
     fun init(appContext: Context) {
+        if (!BuildConfig.ENABLE_ADS) return
         if (!initialized) {
             MobileAds.initialize(appContext.applicationContext) {
                 Log.d(TAG, "MobileAds.initialize complete.")
@@ -36,6 +38,10 @@ object AdsHelper {
     }
 
     fun loadBanner(activity: Activity, adContainer: FrameLayout?) {
+        if (!BuildConfig.ENABLE_ADS) {
+            adContainer?.visibility = View.GONE
+            return
+        }
         if (adContainer == null) {
             Log.e(TAG, "Ad container is null.")
             return
@@ -90,6 +96,7 @@ object AdsHelper {
     }
 
     fun preloadRewarded(context: Context) {
+        if (!BuildConfig.ENABLE_ADS) return
         if (rewardedAd != null || loadingRewarded) return
 
         val adUnitId = context.getString(R.string.admob_reward_id)
@@ -135,6 +142,10 @@ object AdsHelper {
     }
 
     fun showRewarded(activity: Activity, onClosed: (() -> Unit)? = null) {
+        if (!BuildConfig.ENABLE_ADS) {
+            onClosed?.invoke()
+            return
+        }
         val ad = rewardedAd
         if (ad == null) {
             preloadRewarded(activity.applicationContext)

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -7,7 +7,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     app:layoutDescription="@xml/activity_splash_scene"
-    tools:context="com.raylabs.doggie.SplashActivity">
+    tools:context="com.raylabs.doggie.ui.splash.SplashActivity">
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/appCompatImageView"


### PR DESCRIPTION
This commit refactors the project structure and introduces conditional configuration for Firebase Crashlytics and Ads.

Key changes:
- Moved `SplashActivity` to the `ui.splash` package to improve project organization.
- Created a custom `App` class to initialize Firebase Crashlytics.
- Added `ENABLE_CRASHLYTICS` and `ENABLE_ADS` boolean flags in `app/build.gradle` to control their activation in debug and release builds.
- Updated `AdsHelper.kt` to check the `ENABLE_ADS` flag before initializing or displaying ads.
- Modified `AndroidManifest.xml` to reference the new `App` class and the updated `SplashActivity` path.